### PR TITLE
fix: support one seen type of `.bin` file

### DIFF
--- a/hordeling/civitai.py
+++ b/hordeling/civitai.py
@@ -82,7 +82,7 @@ class CivitAIModel:
     def set_pickletensor(self):
         files = self.model_metadata["modelVersions"][0]["files"]
         for f in files:
-            if f["metadata"]["format"] == "Other" and (f["name"].endswith(".pt")):
+            if f["metadata"]["format"] == "Other" and (f["name"].endswith(".pt") or f["name"].endswith(".bin")):
                 f["metadata"]["format"] = "PickleTensor"
             if f["metadata"]["format"] == "PickleTensor":
                 self.pickletensor_url = f["downloadUrl"]


### PR DESCRIPTION
tldr: Now supports the `.bin` file format encountered which recently failed; but maybe not every possible format with a `.bin` extension. Also now detects model conversion failures more verbosely.

I suspect the .bin convert function that was previously present likely only works with diffusion model layouts. Having not seen an example until now, I can better recognize that this particular one uses the same format as `.pt` files. I have left the `if` branch separate in the case there are other competing approaches and to highlight the fact that the file extension is in play.